### PR TITLE
Feature expectations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Code/.idea/
+Code/data/
 *.swap
 *~
 *.pyc

--- a/Code/planner.py
+++ b/Code/planner.py
@@ -19,57 +19,70 @@ class Model(object):
         self.initialize_op = tf.global_variables_initializer()
 
     def build_planner(self):
+        height, width, num_actions = self.height, self.width, self.num_actions
+        dim, gamma = self.feature_dim, self.gamma
+
         self.image = tf.placeholder(
-            tf.float32, name="image", shape=[self.height, self.width])
+            tf.float32, name="image", shape=[height, width])
         self.features = tf.placeholder(
-            tf.float32, name="features", shape=[self.height, self.width, self.feature_dim])
+            tf.float32, name="features", shape=[height, width, dim])
         
         self.weights_list = [
-            self._weight_var(i) for i in range(self.feature_dim)]
+            self._weight_var(i) for i in range(dim)]
         self.weight_inputs = [
-            self._weight_input(i) for i in range(self.feature_dim)]
+            self._weight_input(i) for i in range(dim)]
         self.weight_assignments = [
             w.assign(w_in) for w, w_in in zip(self.weights_list, self.weight_inputs)]
-        self.weights = tf.reshape(
-            tf.concat(self.weights_list, axis=0),
-            [self.feature_dim, 1])
 
-        image_batch = tf.reshape(self.image, [1, self.height, self.width, 1])
-        feature_batch = tf.reshape(
-            self.features, [1, self.height, self.width, self.feature_dim])
+        self.wall_weight = tf.constant([-1000000.0], dtype=tf.float32)
+        self.weights = tf.concat(self.weights_list + [self.wall_weight], axis=0)
+        dim += 1
+
+        image_batch = tf.expand_dims(tf.expand_dims(self.image, 0), 3)
+        feature_batch = tf.expand_dims(self.features, 0)
+        feature_batch = tf.concat([feature_batch, image_batch], axis=3)
 
         # To deal with walls, give a -1000000 reward whenever the agent takes an
-        # action that would move it into a wall. Change the gridworld so that
-        # actions that move the agent into a wall are not available (rather than
-        # causing the agent to stay in place, as it is now).
-        # TODO: Think about episode termination and EXIT actions.
-        # q = r + conv(w, v) + conv(w, self.image)
-        # v = tf.reduce_max(q, axis=3, keep_dims=True, name="v")
+        # action that would move it into a wall.
         north = Direction.get_number_from_direction(Direction.NORTH)
         south = Direction.get_number_from_direction(Direction.SOUTH)
         east = Direction.get_number_from_direction(Direction.EAST)
         west = Direction.get_number_from_direction(Direction.WEST)
 
-        bellman_kernel_value = np.zeros([3, 3, 2, self.num_actions])
-        # No matter what action we take, we get the reward for the current state
-        bellman_kernel_value[1,1,0,:] = [1] * self.num_actions
-        # If you move north, add the discounted value from the state north of
-        # you. Similarly for the other actions.
-        bellman_kernel_value[0,1,1,north] = self.gamma
-        bellman_kernel_value[2,1,1,south] = self.gamma
-        bellman_kernel_value[1,2,1,east] = self.gamma
-        bellman_kernel_value[1,0,1,west] = self.gamma
+        bellman_kernel_value = np.zeros([3, 3, 2*dim, num_actions*dim])
+        for i in range(dim):
+            # For every action, we get the features for the current state
+            bellman_kernel_value[1,1,i,i::dim] = [1.0] * num_actions
+            # If you move north, add the discounted features from the state
+            # north of you. Similarly for the other actions.
+            bellman_kernel_value[0,1,dim+i,north*dim+i] = gamma
+            bellman_kernel_value[2,1,dim+i,south*dim+i] = gamma
+            bellman_kernel_value[1,2,dim+i,east*dim+i] = gamma
+            bellman_kernel_value[1,0,dim+i,west*dim+i] = gamma
         bellman_kernel = tf.constant(bellman_kernel_value, dtype=tf.float32)
 
-        r = tf.tensordot(feature_batch, self.weights, [[3], [0]])
-        v = -1000000 * image_batch
-        for _ in range(self.num_iters):
-            rv = tf.concat([r, v], 3)
-            q = self._conv2d(rv, bellman_kernel, name="q")
-            v = tf.reduce_max(q, axis=3, keep_dims=True, name="v")
-            v -= 1000000 * image_batch
+        index_prefixes = tf.constant(
+            [[[[0, i, j] for j in range(width)] for i in range(height)]],
+            dtype=tf.int64)
 
-        self.q = self._conv2d(rv, bellman_kernel, name="q_final")
+        feature_expectations = tf.zeros([1, height, width, dim])
+        for _ in range(self.num_iters):
+            fv = tf.concat([feature_batch, feature_expectations], axis=3)
+            # TODO: Fix Bellman kernel
+            q_flattened_fes = self._conv2d(fv, bellman_kernel, "q_flat_fe")
+            q_fes = tf.reshape(
+                q_flattened_fes, [1, height, width, num_actions, dim])
+            q_values = tf.tensordot(q_fes, self.weights, [[4], [0]])
+            policy = tf.expand_dims(tf.argmax(q_values, axis=3), -1)
+            indexes = tf.concat([index_prefixes, policy], axis=3)
+            feature_expectations = tf.gather_nd(q_fes, indexes)
+
+        self.feature_expectations = feature_expectations
+        fv = tf.concat([feature_batch, feature_expectations], axis=3)
+        q_flattened_fes = self._conv2d(fv, bellman_kernel, "q_flat_fe")
+        q_fes = tf.reshape(
+            q_flattened_fes, [1, height, width, num_actions, dim])
+        self.q_values = tf.tensordot(q_fes, self.weights, [[4], [0]])
 
     def compute_qvals(self, sess, mdp):
         image, features, _ = mdp.convert_to_numpy_input()
@@ -82,7 +95,7 @@ class Model(object):
             "image:0": image,
             "features:0": features
         }
-        (qvals,) = sess.run([self.q], feed_dict=fd)
+        (qvals,) = sess.run([self.q_values], feed_dict=fd)
         return qvals
 
     def _weight_var(self, i):

--- a/Code/planner_test.py
+++ b/Code/planner_test.py
@@ -13,10 +13,10 @@ class TestPlanner(unittest.TestCase):
         mdp = GridworldMdpWithDistanceFeatures(grid)
         # Hack because agents.py expects mdp.rewards to exist
         mdp.rewards = np.array([1, -1])
-        agent = OptimalAgent(gamma=0.9, num_iters=20)
+        agent = OptimalAgent(gamma=0.9, num_iters=10)
         agent.set_mdp(mdp)
         feature_dim = len(mdp.goals)
-        model = Model(feature_dim, 8, 8, 0.9, 21)
+        model = Model(feature_dim, 8, 8, 0.9, 10)
 
         with tf.Session() as sess:
             sess.run(model.initialize_op)

--- a/Code/planner_test.py
+++ b/Code/planner_test.py
@@ -20,7 +20,7 @@ class TestPlanner(unittest.TestCase):
 
         with tf.Session() as sess:
             sess.run(model.initialize_op)
-            qvals = model.compute_qvals(sess, mdp)
+            (qvals,) = model.compute(['q_values'], sess, mdp, [], mdp.feature_weights)
 
         for state in mdp.get_states():
             if mdp.is_terminal(state):

--- a/Code/query_chooser_class.py
+++ b/Code/query_chooser_class.py
@@ -210,7 +210,7 @@ class Query_Chooser_Subclass(Query_Chooser):
         model = Model(self.args.feature_dim, self.mdp.height, self.mdp.width, self.args.gamma, num_iters,
                       feature_list, self.inference.true_reward_matrix, true_reward)
 
-        with tf.Session as sess:
+        with tf.Session() as sess:
             model_outputs = model.compute(desired_outputs, sess, mdp, init, optimize=True)
             if 'answer' in desired_outputs:
                 answer = model.sample_human_answer()


### PR DESCRIPTION
The Tensorflow planner can now compute feature expectations, though it can still only plan for a single reward function at a time.

Added stubs and interface to the Tensorflow planner, which will be implemented soon.